### PR TITLE
Kick the tires 3): Alter public api for emitting payload + ensure that client renders successfully

### DIFF
--- a/common/autoloads/protocol.gd
+++ b/common/autoloads/protocol.gd
@@ -43,7 +43,6 @@ func _on_remote_build_requested(id, msg: Dictionary) -> void:
 	var generator_resources_data_array := []
 	if msg.has("inputs"): # actually the generator payload of form [{ "node": [{inputs}], "resources": {}}]
 		for generator_payload_data in msg["inputs"]: # of form { "node": [{inputs}], "resources": {}}
-			#print("in _on_remote_build_requested")
 			generator_payload_data_array.append(_node_serializer.deserialize(generator_payload_data))
 	generator_resources_data_array.append(_node_serializer._resources)
 	var args := {

--- a/common/autoloads/remote_manager.gd
+++ b/common/autoloads/remote_manager.gd
@@ -38,33 +38,33 @@ func _set_inputs(tpl: Template, inputs: Array) -> void:
 			#print(input)
 			tpl.set_remote_input(input.name, input)
 
-# resources: [{children:[], name:Path}, {children:[{children:[{children:[], name:fence_planks, resource_path:res://assets/fences/models/fence_planks.glb}], name:tmpParent}], name:fence_planks}]
+# resource_references: [{children:[], name:Path}, {children:[{children:[{children:[], name:fence_planks, resource_path:res://assets/fences/models/fence_planks.glb}], name:tmpParent}], name:fence_planks}]
 # inputs: [Path:[Path:3492], fence_planks:[Position3D:3494]]
-func _set_resources(tpl: Template, inputs: Array, resources: Array, child_transversal: Array = []) -> void:
+func _set_resource_references(tpl: Template, inputs: Array, resource_references: Array, child_transversal: Array = []) -> void:
 	#print("in the remote_manager#_set_resources function")
-	#print(resources)
+	#print(resource_references)
 	if not inputs:
 		return
-	if not resources:
+	if not resource_references:
 		return
 	for input in inputs:
 		if input:
 			#print("cycling through resources to see if there is a match")
-			for resource in resources:
-				#print("current resource ...")
-				#print(resource)
-				if resource && resource["name"] == input.name && resource["resource_path"]:
+			for resource_reference in resource_references:
+				#print("current resource_reference ...")
+				#print(resource_reference)
+				if resource_reference && resource_reference["name"] == input.name && resource_reference["resource_path"]:
 					#print(resource)
 					#print(input)
 					#print(child_transversal)
-					tpl.set_remote_resource(input.name, child_transversal + [resource.name], resource["resource_path"])
+					tpl.set_remote_resource(input.name, child_transversal + [resource_reference.name], resource_reference["resource_path"])
 				else:
-					# TODO: generalise to multiple resources as children of a particular top-level input.
-					# Why "else" condition here at present? Decided a maximum of only one resource per top level input for now (which is admittedly potentially unrealistic for advanced usecases); can be revised later.
+					# TODO: generalise to multiple resource_references as children of a particular top-level input.
+					# Why "else" condition here at present? Decided a maximum of only one resource_reference per top level input for now (which is admittedly potentially unrealistic for advanced usecases); can be revised later.
 					#print("recursing")
-					#print(resource["children"])
+					#print(resource_reference["children"])
 					#print("now here ...")
-					_set_resources(tpl, inputs, resource["children"], child_transversal + [resource.name])
+					_set_resource_references(tpl, inputs, resource_reference["children"], child_transversal + [resource_reference.name])
 
 
 func _on_build_requested(id: int, path: String, args: Dictionary) -> void:
@@ -91,7 +91,7 @@ func _on_build_requested(id: int, path: String, args: Dictionary) -> void:
 	# select the first generator in the relevant array. TODO: find a way to select the appropriate one
 	# if we are invoking multiple generators in a single call to Protongraph
 	_set_inputs(tpl, args["generator_payload_data_array"][0])
-	_set_resources(tpl, args["generator_payload_data_array"][0], args["generator_resources_data_array"][0])
+	_set_resource_references(tpl, args["generator_payload_data_array"][0], args["generator_resources_data_array"][0])
 
 	GlobalEventBus.dispatch("remote_build_started", [id])
 	tpl.generate(true)

--- a/common/static/serializer.gd
+++ b/common/static/serializer.gd
@@ -48,7 +48,7 @@ func serialize(nodes_with_references: Array) -> Dictionary:
 	for node in nodes_with_references[0]["nodes"]:
 		result["nodes"].push_back(_serialize_recursive(node))
 	
-	result["resource_references"].push_back(nodes_with_references[0]["resource_references"])
+	result["resource_references"].push_back(nodes_with_references[0]["resource_references"][0])
 	return result
 
 

--- a/common/static/serializer.gd
+++ b/common/static/serializer.gd
@@ -26,8 +26,13 @@ var _serialized_node_metadata: Dictionary
 # and serializes it into a dictionary.
 #
 # ## Example data:
-# [{nodes:[fence_planks:[Position3D:5697], fence_planks:[Position3D:5701], fence_planks:[Position3D:5705]], resources:[{child_transversal:[fence_planks, tmpParent, fence_planks], remote_resource_path:res://assets/fences/models/fence_planks.glb}]
+# [{nodes:[fence_planks:[Position3D:5697], fence_planks:[Position3D:5701], fence_planks:[Position3D:5705]], resource_references:[{child_transversal:[fence_planks, tmpParent, fence_planks], remote_resource_path:res://assets/fences/models/fence_planks.glb}]
 # ## Example output:
+# {
+#	"resources": []
+#	"nodes": [fence_planks:[Position3D:5697], fence_planks:[Position3D:5701], fence_planks:[Position3D:5705]]
+#   "resource_references": [{child_transversal:[fence_planks, tmpParent, fence_planks], remote_resource_path:res://assets/fences/models/fence_planks.glb}]
+# }
 func serialize(nodes_with_references: Array) -> Dictionary:
 	print("in the serialize function")
 	print(nodes_with_references)
@@ -36,13 +41,14 @@ func serialize(nodes_with_references: Array) -> Dictionary:
 
 	var result: Dictionary = {
 		"resources": [],
+		"resource_references": [],
 		"nodes": []
 	}
 
 	for node in nodes_with_references[0]["nodes"]:
 		result["nodes"].push_back(_serialize_recursive(node))
 	
-	result["resources"].push_back(nodes_with_references[0]["resources"])
+	result["resource_references"].push_back(nodes_with_references[0]["resource_references"])
 	return result
 
 

--- a/common/static/serializer.gd
+++ b/common/static/serializer.gd
@@ -20,21 +20,29 @@ var _serialized_node_metadata: Dictionary
 
 # -- Public API --
 
-# Takes a list of nodes and serialize them all in a dictionary.
-func serialize(nodes: Array) -> Dictionary:
+# Takes data of the form
+#[{nodes:[list_of_nodes], resources:[list_of_resource_references]}]
+# where a resource_reference is of the form {child_transversal:[node_traversal_sequence], remote_resource_path:path_to_resource_in_client}
+# and serializes it into a dictionary.
+#
+# ## Example data:
+# [{nodes:[fence_planks:[Position3D:5697], fence_planks:[Position3D:5701], fence_planks:[Position3D:5705]], resources:[{child_transversal:[fence_planks, tmpParent, fence_planks], remote_resource_path:res://assets/fences/models/fence_planks.glb}]
+# ## Example output:
+func serialize(nodes_with_references: Array) -> Dictionary:
 	print("in the serialize function")
+	print(nodes_with_references)
 	var _resources = []
 	var _serialized_resources = {}
 
 	var result: Dictionary = {
-		"resources": {},
+		"resources": [],
 		"nodes": []
 	}
 
-	for node in nodes:
+	for node in nodes_with_references[0]["nodes"]:
 		result["nodes"].push_back(_serialize_recursive(node))
-
-	result["resources"] = _serialized_resources
+	
+	result["resources"].push_back(nodes_with_references[0]["resources"])
 	return result
 
 

--- a/nodes/outputs/remote_sync_and_post.gd
+++ b/nodes/outputs/remote_sync_and_post.gd
@@ -14,9 +14,9 @@ func _init() -> void:
 
 func _generate_outputs() -> void:
 	#print("in the remote_sync _generate_outputs function")
-	#print("resources %s" % str(get_input(0)))
+	#print("resource_references %s" % str(get_input(0)))
 	#print("nodes %s" % str(get(input(1))))
-	output[0] = { "resources": get_input(0), "nodes": get_input(1) }
+	output[0] = { "resource_references": get_input(0), "nodes": get_input(1) }
 	#print(output[0])
 
 


### PR DESCRIPTION
Alters the public api for emitting payloads back to the client.

Rename "resources" in the return payload to "resource_references" to be more explicit about the information we are sending back.

[![Kicking the tires of Protongraph](https://img.youtube.com/vi/xN11INQlro8/0.jpg)](https://www.youtube.com/watch?v=xN11INQlro8&ab_channel=ChrisGoddard)