### PR TITLE
Tidy up Readme, annotate Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ endef
 
 .PHONY:
 
-
 all: mklove-check compile godot_export package
 
 include mklove/Makefile.base
 
+# nb. this is currently specific to osx. Ideally we should be able to package for linux and windows as well.
 package:
 	mkdir -p bin/protongraph.app/Contents/MacOS/ || echo "build directory already exists"
 	rm -r bin/protongraph.app/Contents/MacOS/secrets || echo "kafka secrets not found"
@@ -38,6 +38,8 @@ package:
 	install_name_tool -change /usr/local/lib/librdkafka.1.dylib @executable_path/librdkafka.1.dylib bin/protongraph.app/Contents/MacOS/$(OUTPUT)
 	install_name_tool -change /usr/local/lib/libmeshoptimizer.dylib @executable_path/libmeshoptimizer.dylib bin/protongraph.app/Contents/MacOS/$(OUTPUT)
 
+# Note that this does not work properly for Godot 3.4.2-stable, possibly due to reasons related to https://github.com/godotengine/godot/issues/44403.
+# Also evidently this is currently specific to osx, one presumably would want to generalise this to windows and linux as well.
 godot_export:
 	./$(GODOT_BINARY) --path . --export "osx" "bin/$(OUTPUT)"
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,6 @@ Protongraph has two modes of operation being Default responder mode, and Kafka p
 
 In Kafka producer mode, Protongraph writes messages it receives via a Websocket connection to a Kafka topic instead.  This mode is useful for instance if Protongraph is deployed to the cloud, and there are up to several additional network hops between the running Godot game and Protongraph, eg Godot game -> Signalling server -> Kafka topic -> Kafka consumer -> Protongraph.  In this instance, the output work from Protongraph would return to the Godot game in potentially a 1 to many relationship via eg Protongraph -> Kafka topic -> Signalling server -> { set of networked clients running the Godot game }.
 
-To build for Default responder mode, run `make` or `make all`.
-
-To build for Kafka producer mode, run `make kafka`.  Note that for this mode you'll need configuration files, see config/Readme.md for more information.
-
 ## Social medias
 
 Despite being a very new project, the ConceptGraph community is growing. Head over to the Discord server if you want to ask for help


### PR DESCRIPTION
Currently command line export does not work, one needs to open the Godot 3.4.2 stable UI and export the project manually.

Also, when exporting manually, the dylib for LibRdKafka does not appear to be automatically mounted, so one would evidently need to edit the package and potentially use the install_name_tool to alter paths to point to relative paths accordingly.