### PR TITLE
Ensure that Protongraph process can handle incoming message from Provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,5 @@ WORKDIR /usr/protongraph
 CMD xvfb-run -a -n 55 -s "-screen 0 1400x900x24 -ac +extension GLX +render -noreset" ./headless --audio-driver Dummy --display-driver headless
 # RUN echo 'sleep infinity' >> /bootstrap.sh
 # RUN chmod +x /bootstrap.sh
-
 # CMD /bootstrap.sh
+EXPOSE 4347

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ COPY config /usr/protongraph/config
 WORKDIR /usr/protongraph
 
 # Hack sourced from here to work around X11 requirement: https://github.com/godotengine/godot/issues/18171#issuecomment-383058814
-# CMD xvfb-run -a -n 55 -s "-screen 0 1400x900x24 -ac +extension GLX +render -noreset" ./headless --audio-driver Dummy --display-driver headless 
-RUN echo 'sleep infinity' >> /bootstrap.sh
-RUN chmod +x /bootstrap.sh
+CMD xvfb-run -a -n 55 -s "-screen 0 1400x900x24 -ac +extension GLX +render -noreset" ./headless --audio-driver Dummy --display-driver headless
+# RUN echo 'sleep infinity' >> /bootstrap.sh
+# RUN chmod +x /bootstrap.sh
 
-CMD /bootstrap.sh
+# CMD /bootstrap.sh

--- a/common/autoloads/lib/server.gd
+++ b/common/autoloads/lib/server.gd
@@ -11,7 +11,11 @@ var _incoming = {}
 
 
 func _ready() -> void:
-	_ws.set_bind_ip("127.0.0.1")
+	# If we set this to localhost then when running headlessly in docker we can't connect to it
+	# from outside the running container, so leave as default wildcard IP instead.
+	# ref: https://docs.godotengine.org/en/stable/classes/class_websocketserver.html#property-descriptions
+	# ref: https://stackoverflow.com/a/54102318/1979000
+	# _ws.set_bind_ip("127.0.0.1")
 	Signals.safe_connect(_ws, "client_connected", self, "_on_client_connected")
 	Signals.safe_connect(_ws, "client_disconnected", self, "_on_client_disconnected")
 	Signals.safe_connect(_ws, "client_close_request", self, "_on_client_close_request")
@@ -93,6 +97,10 @@ func _on_client_disconnected(id: int, clean_close := false) -> void:
 func _on_data_received(client_id: int) -> void:
 	var packet: PoolByteArray = _ws.get_peer(client_id).get_packet()
 	var string = packet.get_string_from_utf8()
+	# For testing purposes only, remove these lines later.
+	#print("Data received from client ", client_id)
+	#var librdkafka = load("res://native/thirdparty/librdkafka/librdkafka.gdns").new()
+	#librdkafka.produce(packet)
 
 	var json = JSON.parse(string)
 	if json.error != OK:

--- a/common/autoloads/project_settings.gd
+++ b/common/autoloads/project_settings.gd
@@ -35,8 +35,7 @@ var _require_restart := [
 
 
 func _ready() -> void:
-	load_or_create_config()
-
+	pass
 
 func has(setting: String) -> bool:
 	return _settings.has(setting)

--- a/common/autoloads/protocol.gd
+++ b/common/autoloads/protocol.gd
@@ -7,7 +7,6 @@ var librdkafka
 
 func _init():
 	librdkafka = load("res://native/thirdparty/librdkafka/librdkafka.gdns").new()
-	librdkafka.produce("look at me i'm writing to kafka")
 
 func _ready():
 	if not _node_serializer:

--- a/native/thirdparty/librdkafka/gdnative/librdkafka.cpp
+++ b/native/thirdparty/librdkafka/gdnative/librdkafka.cpp
@@ -143,6 +143,7 @@ retry:
 }
 
 void LibRdKafka::set_config() {
+  std::cout << "Reading variables from config file.\n" << std::endl;
   std::string config_file_name = "config/kafka.config";
   std::ifstream config_file(config_file_name.c_str());
   std::string line;
@@ -177,10 +178,11 @@ void LibRdKafka::set_config() {
     // We should indicate that there is no configuration set for Kafka.
     pw_config_not_found = true;
   }
-  std::cout << "Broker: " << pw_broker << std::endl;
-  std::cout << "Broker Password: " << pw_broker_password << std::endl;
-  std::cout << "Topic: " << pw_topic << std::endl;
-  std::cout << "Domain: " << pw_domain << std::endl;
+  // The following lines for debugging purposes only.
+  // std::cout << "Broker: " << pw_broker << std::endl;
+  // std::cout << "Broker Password: " << pw_broker_password << std::endl;
+  // std::cout << "Topic: " << pw_topic << std::endl;
+  // std::cout << "Domain: " << pw_domain << std::endl;
 }
 
 void LibRdKafka::set_secrets() {

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-# nb this script only works after compiling for osx
-./bin/protongraph.app/Contents/MacOS/launch
+docker run --name protongraph -p 4347:4347 protongraph

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run --name protongraph -p 4347:4347 protongraph
+docker run --name protongraph -p 4347:4347 --net=bridge protongraph


### PR DESCRIPTION
When the Protongraph-Provider (Kafka consumer) consumes a message, the idea is that this should be sent to the Protongraph-(Worker) process for processing.

The Protongraph worker then should produce to Kafka.  (Changes were made in the previous PR here (https://github.com/token-cjg/protongraph/pull/14) to allow production to Kafka to be done from this process running headlessly in Docker.)

This change:

* Exposes a port (4347) on the Protongraph-Worker to allow incoming tcp connections,
* Forwards port 4347 to this same-said port internal to the container,
* Sets the default network to `bridge` explicitly,
* Names the container `protongraph`,
* Nixes setting the bind_ip of the websocket server, so that the bind_ip is a wildcard instead.  This is necessary since otherwise it is not possible to communicate with the worker process via websocket: https://stackoverflow.com/a/54102318/1979000.