### PR TITLE
Load from template content

### DIFF
--- a/common/autoloads/protocol.gd
+++ b/common/autoloads/protocol.gd
@@ -125,7 +125,8 @@ func _on_remote_build_requested(id, msg: Dictionary) -> void:
 	print("[IPC] Remote build requested")
 	var path: String
 	var tpgn: String
-	if not msg.has("path") or not msg.has("tpgn"):
+	if not msg.has("path") and not msg.has("tpgn"):
+		print("[IPC] Remote build requested, but missing path and tpgn")
 		return
 	if msg.has("tpgn"):
 		tpgn = msg["tpgn"]

--- a/common/autoloads/protocol.gd
+++ b/common/autoloads/protocol.gd
@@ -123,10 +123,13 @@ func _on_data_received(id: int , data: Dictionary) -> void:
 # as well as several optional values.
 func _on_remote_build_requested(id, msg: Dictionary) -> void:
 	print("[IPC] Remote build requested")
-	if not msg.has("path"):
+	var path: String, tpgn: String
+	if not msg.has("path") or not msg.has("tpgn"):
 		return
-
-	var path: String = msg["path"]
+	if msg.has("tpgn"):
+		tpgn, path = msg["tpgn"], ""
+	elif msg.has("path"):
+		path, tpgn = msg["path"], ""
 	var inspector: Array = msg["inspector"] if msg.has("inspector") else null
 	var generator_payload_data_array := []
 	var generator_resources_data_array := []
@@ -139,7 +142,7 @@ func _on_remote_build_requested(id, msg: Dictionary) -> void:
 		"generator_payload_data_array": generator_payload_data_array,
 		"generator_resources_data_array": generator_resources_data_array
 	}
-	GlobalEventBus.dispatch("build_for_remote", [id, path, args])
+	GlobalEventBus.dispatch("build_for_remote", [id, path, tpgn, args])
 
 
 func _on_remote_build_completed(id, data: Array) -> void:

--- a/common/autoloads/protocol.gd
+++ b/common/autoloads/protocol.gd
@@ -123,13 +123,16 @@ func _on_data_received(id: int , data: Dictionary) -> void:
 # as well as several optional values.
 func _on_remote_build_requested(id, msg: Dictionary) -> void:
 	print("[IPC] Remote build requested")
-	var path: String, tpgn: String
+	var path: String
+	var tpgn: String
 	if not msg.has("path") or not msg.has("tpgn"):
 		return
 	if msg.has("tpgn"):
-		tpgn, path = msg["tpgn"], ""
+		tpgn = msg["tpgn"]
+		path = ""
 	elif msg.has("path"):
-		path, tpgn = msg["path"], ""
+		path = msg["path"]
+		tpgn = ""
 	var inspector: Array = msg["inspector"] if msg.has("inspector") else null
 	var generator_payload_data_array := []
 	var generator_resources_data_array := []

--- a/common/autoloads/remote_manager.gd
+++ b/common/autoloads/remote_manager.gd
@@ -51,7 +51,7 @@ func _set_resource_references(tpl: Template, inputs: Array, resource_references:
 					_set_resource_references(tpl, inputs, resource_reference["children"], child_transversal + [resource_reference.name])
 
 
-func _on_build_requested(id: int, path: String, args: Dictionary) -> void:
+func _on_build_requested(id: int, path: String, tpgn: String, args: Dictionary) -> void:
 	var tpl: Template
 	if _peers.has(id):
 		tpl = _peers[id]["template"]
@@ -61,7 +61,12 @@ func _on_build_requested(id: int, path: String, args: Dictionary) -> void:
 		_peers[id] = {}
 		_peers[id]["template"] = tpl
 
-	if tpl._loaded_template_path != path:
+	# When Protongraph is deployed to the cloud, the idea is to pass in the entire template as a string,
+	# else if we're running locally, we'd like to pass in the template's path.
+	# (Passing in the local path is helpful when we are running Protongraph as an interactive application.)
+	if tpgn != "":
+		tpl.load_from_tpgn(tpgn)
+	elif path != "" and tpl._loaded_template_path != path:
 		tpl.load_from_file(path)
 
 	if not tpl._template_loaded:

--- a/core/template.gd
+++ b/core/template.gd
@@ -210,7 +210,6 @@ func create_node(type: String, data := {}, notify := true) -> ProtonNode:
 
 	new_node.thread_pool = _thread_pool
 	new_node.template_path = _loaded_template_path
-	new_node.template_content = _loaded_template_content
 
 	if data.has("offset"):
 		new_node.offset = data["offset"]

--- a/core/template.gd
+++ b/core/template.gd
@@ -62,13 +62,13 @@ func _exit_tree() -> void:
 	if _thread and _thread.is_active():
 		_thread.wait_to_finish()
 
-func process_tpgn(json: Dictionary) -> void:
-	if not json or not json.result:
+func process_tpgn(jsonParseResult: JSONParseResult) -> void:
+	if not jsonParseResult or not jsonParseResult.result:
 		print("Failed to parse the template content")
 		return	# Template content is either empty or not a valid Json. Ignore
 
 	# Abort if the template content doesn't have node data
-	var graph: Dictionary = DictUtil.fix_types(json.result)
+	var graph: Dictionary = DictUtil.fix_types(jsonParseResult.result)
 	if not graph.has("nodes"):
 		return
 
@@ -122,8 +122,8 @@ func load_from_tpgn(tpgn: String, soft_load := false) -> void:
 	else:
 		clear()
 
-	var json: Dictionary = JSON.parse(tpgn)
-	process_tpgn(json)
+	var jsonParseResult: JSONParseResult = JSON.parse(tpgn)
+	process_tpgn(jsonParseResult)
 
 # Opens a pgraph file, reads its contents and recreate a node graph from there
 func load_from_file(path: String, soft_load := false) -> void:

--- a/core/template.gd
+++ b/core/template.gd
@@ -44,7 +44,7 @@ var _proxy_nodes := {}
 var _remote_inputs := {}
 var _remote_resources := {}
 var _loaded_template_path: String
-
+var _loaded_template_content: String
 
 func _init() -> void:
 	Signals.safe_connect(self, "thread_completed", self, "_on_thread_completed")
@@ -62,35 +62,17 @@ func _exit_tree() -> void:
 	if _thread and _thread.is_active():
 		_thread.wait_to_finish()
 
-
-# Opens a pgraph file, reads its contents and recreate a node graph from there
-func load_from_file(path: String, soft_load := false) -> void:
-	if not path or path == "":
-		return
-
-	paused = true
-	_template_loaded = false
-	_loaded_template_path = path
-
-	if soft_load:	# Don't clear, simply refresh the graph edit UI without running the sim
-		clear_editor()
-	else:
-		clear()
-
-	# Open the file and read the contents
-	var file = File.new()
-	file.open(path, File.READ)
-	var json = JSON.parse(file.get_as_text())
+func process_tpgn(json: Dictionary) -> void:
 	if not json or not json.result:
-		print("Failed to parse the template file")
-		return	# Template file is either empty or not a valid Json. Ignore
+		print("Failed to parse the template content")
+		return	# Template content is either empty or not a valid Json. Ignore
 
-	# Abort if the file doesn't have node data
+	# Abort if the template content doesn't have node data
 	var graph: Dictionary = DictUtil.fix_types(json.result)
 	if not graph.has("nodes"):
 		return
 
-	# For each node found in the template file
+	# For each node found in the template content
 	for node_data in graph["nodes"]:
 		if node_data.has("type"):
 			var type = node_data["type"]
@@ -127,6 +109,41 @@ func load_from_file(path: String, soft_load := false) -> void:
 	_template_loaded = true
 	paused = false
 	emit_signal("template_loaded")
+
+func load_from_tpgn(tpgn: String, soft_load := false) -> void:
+	if not tpgn or tpgn == "":
+		return
+	paused = true
+	_template_loaded = false
+	_loaded_template_content = tpgn
+
+	if soft_load:	# Don't clear, simply refresh the graph edit UI without running the sim
+		clear_editor()
+	else:
+		clear()
+
+	var json: Dictionary = JSON.parse(tpgn)
+	process_tpgn(json)
+
+# Opens a pgraph file, reads its contents and recreate a node graph from there
+func load_from_file(path: String, soft_load := false) -> void:
+	if not path or path == "":
+		return
+
+	paused = true
+	_template_loaded = false
+	_loaded_template_path = path
+
+	if soft_load:	# Don't clear, simply refresh the graph edit UI without running the sim
+		clear_editor()
+	else:
+		clear()
+
+	# Open the file and read the contents
+	var file = File.new()
+	file.open(path, File.READ)
+	var json = JSON.parse(file.get_as_text())
+	process_tpgn(json)
 	GlobalEventBus.dispatch("template_loaded", path)
 
 
@@ -193,6 +210,7 @@ func create_node(type: String, data := {}, notify := true) -> ProtonNode:
 
 	new_node.thread_pool = _thread_pool
 	new_node.template_path = _loaded_template_path
+	new_node.template_content = _loaded_template_content
 
 	if data.has("offset"):
 		new_node.offset = data["offset"]
@@ -360,6 +378,8 @@ func get_remote_output() -> Array:
 func get_template_path() -> String:
 	return _loaded_template_path
 
+func get_template_content() -> String:
+	return _loaded_template_content
 
 func get_remote_input(name: String):
 	if name in _remote_inputs:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 if [ $1 == "stop" ]; then
-  processId=$(ps | grep "./godot\.osx" | cut -d " " -f2)
-  kill -9 $processId
-  processId=$(ps | grep "./godot\.osx" | cut -d " " -f1)
+  processId=$(ps | grep "./godot\.osx" | awk '{print $1}')
   kill -9 $processId
 fi
 

--- a/ui/views/editor/components/nodes/components/string.gd
+++ b/ui/views/editor/components/nodes/components/string.gd
@@ -3,6 +3,7 @@ class_name StringComponent
 
 
 var template_path: String
+var template_content: String
 
 var _line_edit: LineEdit
 var _dropdown: OptionButton


### PR DESCRIPTION
There is an issue with building remotely in that the Protongraph (worker) process will be on a different machine than the one running the client - which has the tpgn file representing the bill of work for Protongraph to process.

Let's fix this by allowing Protongraph to accept and process a "tpgn" attribute if present on an incoming message, and use this as an override in lieu of "path" for information to populate the template when a remote build is requested.

Also applies a fix to the "dev" script which was a bit messy before.

Companion PR in TestProtongraphProject here: https://github.com/token-cjg/TestProtongraphProject/pull/6.