### PR TITLE
Disconnect peer once all packets received

### DIFF
--- a/common/autoloads/lib/server.gd
+++ b/common/autoloads/lib/server.gd
@@ -127,6 +127,7 @@ func _on_data_received(client_id: int) -> void:
 	# Decode once we've received all the chunks
 	if _incoming[packet_id].size() == total_chunks:
 		print("Received all chunks for packet ", packet_id)
+		_ws.start() # Restart the server to receive more data and also notify the provider that the message has been received.
 		var instanceServiceId: int
 		var instanceId: String
 		var peerKey: String
@@ -163,8 +164,6 @@ func _decode(packet_id: int, client_id: int) -> void:
 	if _incoming[packet_id].has("metadata"):
 		data["metadata"] = _incoming[packet_id]["metadata"]
 	emit_signal("data_received", client_id, data)
-	_ws.close_peer(client_id)
-
 
 func _on_client_close_request(id: int, code: int, reason: String) -> void:
 	print("Client close request ", id, " reason: ", reason)

--- a/common/autoloads/lib/server.gd
+++ b/common/autoloads/lib/server.gd
@@ -95,7 +95,7 @@ func _on_client_disconnected(id: int, clean_close := false) -> void:
 
 
 func _on_data_received(client_id: int) -> void:
-	print("Data received from client ", client_id)
+	# print("Data received from client ", client_id)
 	var packet: PoolByteArray = _ws.get_peer(client_id).get_packet()
 	var string = packet.get_string_from_utf8()
 	# For testing purposes only, remove these lines later.
@@ -112,8 +112,8 @@ func _on_data_received(client_id: int) -> void:
 	# print("in _on_data_received")
 	# print(jsonParseResult.result)
 	var data = DictUtil.fix_types(jsonParseResult.result)
-	print("printing data")
-	print(data)
+	# print("printing data")
+	# print(data)
 	
 	var packet_id = int(data["packetId"])
 	var chunk_id = int(data["chunkId"])
@@ -126,7 +126,7 @@ func _on_data_received(client_id: int) -> void:
 	_incoming[packet_id][chunk_id] = chunk
 	# Decode once we've received all the chunks
 	if _incoming[packet_id].size() == total_chunks:
-		print("Received all chunks for packet ", packet_id)
+		# print("Received all chunks for packet ", packet_id)
 		_ws.disconnect_peer(
 			client_id,
 			1000,

--- a/common/autoloads/lib/server.gd
+++ b/common/autoloads/lib/server.gd
@@ -127,7 +127,11 @@ func _on_data_received(client_id: int) -> void:
 	# Decode once we've received all the chunks
 	if _incoming[packet_id].size() == total_chunks:
 		print("Received all chunks for packet ", packet_id)
-		_ws.start() # Restart the server to receive more data and also notify the provider that the message has been received.
+		_ws.disconnect_peer(
+			client_id,
+			1000,
+			"All chunks received"
+		)
 		var instanceServiceId: int
 		var instanceId: String
 		var peerKey: String

--- a/common/autoloads/lib/server.gd
+++ b/common/autoloads/lib/server.gd
@@ -95,6 +95,7 @@ func _on_client_disconnected(id: int, clean_close := false) -> void:
 
 
 func _on_data_received(client_id: int) -> void:
+	print("Data received from client ", client_id)
 	var packet: PoolByteArray = _ws.get_peer(client_id).get_packet()
 	var string = packet.get_string_from_utf8()
 	# For testing purposes only, remove these lines later.
@@ -111,8 +112,8 @@ func _on_data_received(client_id: int) -> void:
 	# print("in _on_data_received")
 	# print(jsonParseResult.result)
 	var data = DictUtil.fix_types(jsonParseResult.result)
-	# print("printing data")
-	# print(data)
+	print("printing data")
+	print(data)
 	
 	var packet_id = int(data["packetId"])
 	var chunk_id = int(data["chunkId"])
@@ -162,6 +163,7 @@ func _decode(packet_id: int, client_id: int) -> void:
 	if _incoming[packet_id].has("metadata"):
 		data["metadata"] = _incoming[packet_id]["metadata"]
 	emit_signal("data_received", client_id, data)
+	_ws.close_peer(client_id)
 
 
 func _on_client_close_request(id: int, code: int, reason: String) -> void:


### PR DESCRIPTION
This is required so that the provider has the signal as to when to listen for a new packet